### PR TITLE
Code Coverage in Pull Requests

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     types:
       - closed
+    branches:
+      - 'main'
 
 jobs:
   publish:

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -10,9 +10,13 @@ on:
       - ready_for_review
     branches:
       - 'main'
+      - 'test-artifacts'
 
 jobs:
   build:
+    permissions:
+      pull-requests: write # Required for writing comments to the pull request
+      
     runs-on: ubuntu-latest
 
     steps:
@@ -37,9 +41,29 @@ jobs:
         run: dotnet restore
       - name: Build
         run: dotnet build Letterbook.ActivityPub.sln
-#        TODO: test results and coverage
       - name: Test
-        run: dotnet test Letterbook.ActivityPub.sln
+        run: dotnet test Letterbook.ActivityPub.sln --collect:"XPlat Code Coverage" --results-directory "coverage"
+      - name: Code Coverage Report
+#        TODO: We may want to fork these 3rd party actions
+        uses: irongut/CodeCoverageSummary@v1.3.0
+        with:
+          filename: coverage/**/coverage.cobertura.xml
+          badge: true
+          fail_below_min: false
+          format: markdown
+          hide_branch_rate: false
+          hide_complexity: true
+          indicators: true
+          output: both
+          thresholds: '60 80'
+      - name: Add Coverage PR Comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        if: github.event_name == 'pull_request'
+        with:
+        # When re-run, hide existing comments and creates a new one
+          hide_and_recreate: true
+          hide_classify: "OUTDATED"
+          path: code-coverage-results.md
       - name: Package for Nuget
         run: 'dotnet pack Letterbook.ActivityPub -p:PackageVersion=$PACKAGE_VERSION -o ./'
         env: 
@@ -51,3 +75,10 @@ jobs:
           path: ./*.nupkg
           if-no-files-found: error
           retention-days: 7
+      - name: Save test result artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-results
+          path: coverage
+        # Even if the tests fail - publish the results
+        if: always()

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -56,14 +56,6 @@ jobs:
           indicators: true
           output: both
           thresholds: '60 80'
-      - name: Add Coverage PR Comment
-        uses: marocchino/sticky-pull-request-comment@v2
-        if: github.event_name == 'pull_request'
-        with:
-        # When re-run, hide existing comments and creates a new one
-          hide_and_recreate: true
-          hide_classify: "OUTDATED"
-          path: code-coverage-results.md
       - name: Package for Nuget
         run: 'dotnet pack Letterbook.ActivityPub -p:PackageVersion=$PACKAGE_VERSION -o ./'
         env: 


### PR DESCRIPTION
Implements the start of #12 

Collects coverage data during testing and publishes that as a comment to the pull request. These comments appear like:

![image](https://github.com/Letterbook/Letterbook.ActivityPub/assets/1161329/273f413a-eed0-4e80-a5f6-f100c0d8bb35)

Repeated runs will hide stale coverage reports and replace them with new data.

An artifact is also stored with the test report for reference.

There's more we can do here I think, but it's a start we can build from.