### PR TITLE
Add Code Coverage Results to PR

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -56,6 +56,14 @@ jobs:
           indicators: true
           output: both
           thresholds: '60 80'
+      - name: Add Coverage PR Comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        if: github.event_name == 'pull_request'
+        with:
+        # When re-run, hide existing comments and creates a new one
+          hide_and_recreate: true
+          hide_classify: "OUTDATED"
+          path: code-coverage-results.md
       - name: Package for Nuget
         run: 'dotnet pack Letterbook.ActivityPub -p:PackageVersion=$PACKAGE_VERSION -o ./'
         env: 


### PR DESCRIPTION
This is part of #12 and adds a comment to PR's with test coverage reports to make those results more visible.