### PR TITLE
Selectively serialize Links into strings

### DIFF
--- a/Letterbook.ActivityPub.Tests/ConvertObjectWriterTests.cs
+++ b/Letterbook.ActivityPub.Tests/ConvertObjectWriterTests.cs
@@ -113,4 +113,29 @@ public class ConvertObjectWriterTests
 
         Assert.DoesNotMatch("@context", actual);
     }
+    
+    [Fact]
+    public void SerializeLinksAsString_WhenOnlyHRefIsSet()
+    {
+        var link = new Link("https://example.com/");
+        var output = JsonSerializer.Serialize<IResolvable>(link, JsonOptions.ActivityPub);
+        Assert.Equal("\"https://example.com/\"", output);
+    }
+
+    [Fact]
+    public void SerializeLinksAsObject_WhenPropertiesAreSet()
+    {
+        var link = new Link("https://example.com/")
+        {
+            Rel = "me"
+        };
+        
+        var output = JsonSerializer.SerializeToElement<IResolvable>(link, JsonOptions.ActivityPub);
+        
+        Assert.Equal(JsonValueKind.Object, output.ValueKind);
+        Assert.True(output.TryGetProperty("href", out var href));
+        Assert.Equal("https://example.com/", href.GetString());
+        Assert.True(output.TryGetProperty("rel", out var rel));
+        Assert.Equal("me", rel.GetString());
+    }
 }


### PR DESCRIPTION
This PR implements logic to selectively serialize `Link` objects as strings. This alternate path will be triggered only if the Link has no extra properties set. Assigning a value to `rel`, `hreflang`, or any other property will force the Link to serialize as an object.

## Details
- `ConvertResolvable` is upgraded to add the additional case. Now the Link branch is further divided based on the logic described above.
- The check for "other properties" is kind of clunky and far from ideal. For simplicity, this implementation simply enumerates and checks all possible properties against their default values. That works reliably for the current object model, but may need an overhaul if/when extensions are implemented.
- Unit tests for both code paths are added in `ConvertObjectWriterTests`.

## Related
- Implements #24 
