### PR TITLE
Adding support for additional types required by mastodon

### DIFF
--- a/Letterbook.ActivityPub.Tests/ConvertObjectReaderTest.cs
+++ b/Letterbook.ActivityPub.Tests/ConvertObjectReaderTest.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using System.Reflection;
 using System.Text.Json;
 using Letterbook.ActivityPub.Models;
@@ -62,6 +61,7 @@ public class ConvertObjectReaderTest
         Assert.Equal("https://mastodon.example/users/test_actor/followers", actual.Followers.Id.ToString());
         Assert.Equal("https://mastodon.example/users/test_actor/inbox", actual.Inbox.Id.ToString());
         Assert.Equal("https://mastodon.example/users/test_actor/outbox", actual.Outbox.Id.ToString());
+        Assert.NotNull(actual.PublicKey?.PublicKeyPem);
     }
 
     [Trait("JsonConvert", "Marshall")]

--- a/Letterbook.ActivityPub.Tests/ConvertObjectReaderTest.cs
+++ b/Letterbook.ActivityPub.Tests/ConvertObjectReaderTest.cs
@@ -62,6 +62,13 @@ public class ConvertObjectReaderTest
         Assert.Equal("https://mastodon.example/users/test_actor/inbox", actual.Inbox.Id.ToString());
         Assert.Equal("https://mastodon.example/users/test_actor/outbox", actual.Outbox.Id.ToString());
         Assert.NotNull(actual.PublicKey?.PublicKeyPem);
+        Assert.True(actual.Attachment
+            .Aggregate(false, (result, each) => result || (each as PropertyValue)?.Name == "email"),
+            "Name missing");
+        Assert.True(actual.Attachment
+            .Aggregate(false, (result, each) => result || (each as PropertyValue)?.Value == "test_actor@example.com"),
+            "Value missing");
+        // Assert.Contains(actual.Attachment, new PropertyValue() { Name = "email", Value = "test_actor@example.com" });
     }
 
     [Trait("JsonConvert", "Marshall")]

--- a/Letterbook.ActivityPub.Tests/ConvertObjectReaderTest.cs
+++ b/Letterbook.ActivityPub.Tests/ConvertObjectReaderTest.cs
@@ -68,7 +68,6 @@ public class ConvertObjectReaderTest
         Assert.True(actual.Attachment
             .Aggregate(false, (result, each) => result || (each as PropertyValue)?.Value == "test_actor@example.com"),
             "Value missing");
-        // Assert.Contains(actual.Attachment, new PropertyValue() { Name = "email", Value = "test_actor@example.com" });
     }
 
     [Trait("JsonConvert", "Marshall")]

--- a/Letterbook.ActivityPub.Tests/ConvertObjectWriterTests.cs
+++ b/Letterbook.ActivityPub.Tests/ConvertObjectWriterTests.cs
@@ -59,6 +59,26 @@ public class ConvertObjectWriterTests
         Assert.Matches("https://mastodon.example/schema#", actual);
         Assert.Matches("@context", actual);
     }
+    
+    [Fact]
+    public void SerializeSupportedLdContext()
+    {
+        var opts = JsonOptions.ActivityPub;
+        var testObject = new Models.Object
+        {
+            LdContext = LdContext.SupportedContexts,
+            Content = "test content",
+            Id = new CompactIri("https://letterbook.example/1"),
+            Type = "Note"
+        };
+
+        var actual = JsonSerializer.Serialize(testObject, opts);
+
+        Assert.Matches("https://www.w3.org/ns/activitystreams", actual);
+        Assert.Matches("https://w3id.org/security/v1", actual);
+        Assert.Matches("http://schema.org", actual);
+        Assert.Matches("@context", actual);
+    }
 
     [Fact]
     public void SerializeSingleLdContext()

--- a/Letterbook.ActivityPub/ConvertResolvable.cs
+++ b/Letterbook.ActivityPub/ConvertResolvable.cs
@@ -34,7 +34,7 @@ public class ConvertResolvable : JsonConverter<IResolvable>
                     {
                         return JsonSerializer.Deserialize<Link>(reader: ref reader, options);
                     }
-                    if (string.Compare(next, "Actor", StringComparison.InvariantCultureIgnoreCase) == 0)
+                    if (Actor.Types.Contains(next, StringComparer.InvariantCultureIgnoreCase))
                     {
                         return JsonSerializer.Deserialize<Actor>(ref reader, options);
                     }
@@ -51,6 +51,10 @@ public class ConvertResolvable : JsonConverter<IResolvable>
                     if (Activity.Types.Contains(next, StringComparer.InvariantCultureIgnoreCase))
                     {
                         return JsonSerializer.Deserialize<Activity>(ref reader, options);
+                    }
+                    if (string.Compare(next, "PropertyValue", StringComparison.InvariantCultureIgnoreCase) == 0)
+                    {
+                        return JsonSerializer.Deserialize<PropertyValue>(ref reader, options);
                     }
                     
                     return JsonSerializer.Deserialize<Object>(ref reader, options);

--- a/Letterbook.ActivityPub/ExtendedModels/PropertyValue.cs
+++ b/Letterbook.ActivityPub/ExtendedModels/PropertyValue.cs
@@ -1,0 +1,14 @@
+﻿namespace Letterbook.ActivityPub.Models;
+
+public class PropertyValue : Object
+{
+    public new string Type
+    {
+        get => "PropertyString";
+        set => base.Type = value;
+    }
+
+    public new required string Name { get; set; }
+    public required string Value { get; set; }
+    
+}

--- a/Letterbook.ActivityPub/ExtendedModels/PublicKey.cs
+++ b/Letterbook.ActivityPub/ExtendedModels/PublicKey.cs
@@ -1,0 +1,7 @@
+﻿namespace Letterbook.ActivityPub.Models;
+
+public class PublicKey : Object
+{
+    public IResolvable Owner { get; set; }
+    public string PublicKeyPem { get; set; }
+}

--- a/Letterbook.ActivityPub/Models/Actor.cs
+++ b/Letterbook.ActivityPub/Models/Actor.cs
@@ -10,4 +10,16 @@ public class Actor : Object
     public Collection? Followers { get; set; }
     public Collection? Liked { get; set; }
     public Collection? Streams { get; set; }
+    public ActorEndpoints? Endpoints { get; set; }
+    public PublicKey? PublicKey { get; set; }
+
+    public class ActorEndpoints
+    {
+        public Uri? ProxyUrl { get; set; }
+        public Uri? OauthAuthorizationEndpoint { get; set; }
+        public Uri? OauthTokenEndpoint { get; set; }
+        public Uri? ProvideClientKey { get; set; }
+        public Uri? SignClientKey { get; set; }
+        public Uri? SharedInbox { get; set; }
+    }
 }

--- a/Letterbook.ActivityPub/Models/Actor.cs
+++ b/Letterbook.ActivityPub/Models/Actor.cs
@@ -4,6 +4,16 @@ namespace Letterbook.ActivityPub.Models;
 
 public class Actor : Object
 {
+    public static List<string> Types = new(new[]
+    {
+        "Actor",
+        "Application",
+        "Group",
+        "Organization",
+        "Person",
+        "Service",
+    });
+    
     [Required] public Collection Inbox { get; set; } = new Collection { Type = "OrderedCollection" };
     [Required] public Collection Outbox { get; set; } = new Collection { Type = "OrderedCollection" };
     public Collection? Following { get; set; }

--- a/Letterbook.ActivityPub/Models/LdContext.cs
+++ b/Letterbook.ActivityPub/Models/LdContext.cs
@@ -3,6 +3,18 @@
 public class LdContext : IEquatable<LdContext>
 {
     public static LdContext ActivityStreams = new LdContext("https://www.w3.org/ns/activitystreams");
+
+    public static IEnumerable<LdContext> SupportedContexts = new List<LdContext>
+    {
+        ActivityStreams,
+        new("https://w3id.org/security/v1"),
+        new("http://schema.org"),
+        new("as", "https://www.w3.org/ns/activitystreams#"),
+        new("sec", "https://w3id.org/security/v1#"),
+        new("publicKey", "sec:publicKey"),
+        new("schema", "http://schema.org#"),
+        new("PropertyValue", "schema:PropertyValue"),
+    };
     
     public string? Prefix { get; set; }
     public string Suffix { get; set; }


### PR DESCRIPTION
Literally, none of this should be necessary. As much as ActivityPub is incomplete as the basis for a federated social network, it's more complete than this. Same with HttpSignatures, even 5+ year old drafts. There is absolutely no reason that these properties should be *required* for mastodon to do it's thing. But here we are.

Also, this is wildly unsustainable. This is an absolutely terrible way to support extensions. But that's ok, it should be the last time. At some point in the near future, I expect to drop this library and switch to ActivityPubSharp, which has much more robust extension mechanisms.

## Related
- Supports Letterbook/Letterbook#111