### PR TITLE
Serialize objects as strings when possible

### DIFF
--- a/Letterbook.ActivityPub.Tests/ConvertObjectWriterTests.cs
+++ b/Letterbook.ActivityPub.Tests/ConvertObjectWriterTests.cs
@@ -16,7 +16,7 @@ public class ConvertObjectWriterTests
             Id = new CompactIri("https://letterbook.example/1")
         };
 
-        var actual = JsonSerializer.Serialize(testObject);
+        var actual = JsonSerializer.Serialize(testObject, JsonOptions.ActivityPub);
 
         Assert.Matches("https://letterbook.example/1", actual);
     }
@@ -158,5 +158,15 @@ public class ConvertObjectWriterTests
         Assert.Equal("https://example.com/", href.GetString());
         Assert.True(output.TryGetProperty("rel", out var rel));
         Assert.Equal("me", rel.GetString());
+    }
+
+    [Fact]
+    public void SerializeObjectAsString_WhenOnlyIdIsSet()
+    {
+        var col = new Collection() { Id = "https://example.com/collection/0" };
+
+        var actual = JsonSerializer.Serialize<IResolvable>(col, JsonOptions.ActivityPub);
+        
+        Assert.Equal("\"https://example.com/collection/0\"", actual);
     }
 }

--- a/Letterbook.ActivityPub/Models/Object.cs
+++ b/Letterbook.ActivityPub/Models/Object.cs
@@ -6,7 +6,8 @@ namespace Letterbook.ActivityPub.Models;
 public class Object : IResolvable
 {
     private IEnumerable<LdContext> _ldContext = new HashSet<LdContext>();
-
+    
+    [JsonPropertyOrder(-10)]
     [JsonPropertyName("@context")]
     [JsonConverter(typeof(ConvertContext))]
     public IEnumerable<LdContext> LdContext
@@ -15,7 +16,9 @@ public class Object : IResolvable
         set => _ldContext = value;
     }
 
+    [JsonPropertyOrder(-6)]
     public CompactIri? Id { get; set; }
+    [JsonPropertyOrder(-5)]
     public string Type { get; set; } = string.Empty;
 
     [JsonConverter(typeof(ConvertList<IResolvable>))]


### PR DESCRIPTION
And sort serialized properties for easier marshaling and readability

## Details
- This shouldn't be strictly necessary, but I found that collections on Actors were serializing in a very unpleasant way.
- This gives json that looks like the examples from the AP spec.
